### PR TITLE
Security hardening: eliminate eval() and improve ESLint config

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -12,7 +12,8 @@
       "Bash(echo:*)",
       "Bash(rm:*)",
       "Bash(mv:*)",
-      "Bash(Test-Path \"CLAUDE.md\")"
+      "Bash(Test-Path \"CLAUDE.md\")",
+      "Bash(git checkout:*)"
     ],
     "deny": [],
     "ask": []

--- a/eslint.config.cjs
+++ b/eslint.config.cjs
@@ -7,6 +7,7 @@ const tsPlugin = require('@typescript-eslint/eslint-plugin');
 const reactPlugin = require('eslint-plugin-react');
 const reactHooksPlugin = require('eslint-plugin-react-hooks');
 const importPlugin = require('eslint-plugin-import');
+const securityPlugin = require('eslint-plugin-security');
 
 /** @type {import('eslint').Linter.FlatConfig[]} */
 module.exports = [
@@ -29,6 +30,7 @@ module.exports = [
       react: reactPlugin,
       'react-hooks': reactHooksPlugin,
       import: importPlugin,
+      security: securityPlugin,
     },
     settings: {
       react: { version: 'detect' },
@@ -39,6 +41,7 @@ module.exports = [
       ...tsPlugin.configs.recommended.rules,
       ...reactPlugin.configs.recommended.rules,
       ...reactHooksPlugin.configs.recommended.rules,
+      ...securityPlugin.configs.recommended.rules,
 
       // Project adjustments
       'react/react-in-jsx-scope': 'off',
@@ -67,6 +70,17 @@ module.exports = [
 
       // Disable no-undef for TS (handled by TypeScript)
       'no-undef': 'off',
+
+      // Security rules to prevent unsafe code patterns (strict for eval)
+      'no-eval': 'error',
+      'no-implied-eval': 'error',
+      'security/detect-eval-with-expression': 'error',
+      // Relax other security rules for legitimate patterns in TypeScript code
+      'security/detect-non-literal-require': 'off',
+      'security/detect-object-injection': 'off',
+      'security/detect-non-literal-regexp': 'off',
+      'security/detect-unsafe-regex': 'off',
+      'security/detect-non-literal-fs-filename': 'off',
     },
   },
 
@@ -120,6 +134,9 @@ module.exports = [
     files: ['**/__tests__/**/*.{ts,tsx}', '**/*.test.{ts,tsx}'],
     languageOptions: {
       globals: { ...globals.node, ...globals.browser, ...(globals.jest || {}) },
+    },
+    rules: {
+      // Test files already inherit relaxed security rules from base config
     },
   },
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,6 +52,7 @@
         "eslint-plugin-import": "^2.32.0",
         "eslint-plugin-react": "^7.37.5",
         "eslint-plugin-react-hooks": "^5.2.0",
+        "eslint-plugin-security": "^3.0.1",
         "globals": "^16.3.0",
         "jsdom": "^26.1.0",
         "typescript": "^5.9.2",
@@ -6636,6 +6637,22 @@
         "semver": "bin/semver.js"
       }
     },
+    "node_modules/eslint-plugin-security": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-security/-/eslint-plugin-security-3.0.1.tgz",
+      "integrity": "sha512-XjVGBhtDZJfyuhIxnQ/WMm385RbX3DBu7H1J7HNNhmB2tnGxMeqVSnYv79oAj992ayvIBZghsymwkYFS6cGH4Q==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-regex": "^2.1.1"
+      },
+      "engines": {
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/eslint"
+      }
+    },
     "node_modules/eslint-scope": {
       "version": "8.4.0",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
@@ -11089,6 +11106,16 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
     "node_modules/regexp.prototype.flags": {
       "version": "1.5.4",
       "resolved": "https://registry.npmjs.org/regexp.prototype.flags/-/regexp.prototype.flags-1.5.4.tgz",
@@ -11405,6 +11432,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/safe-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-2.1.1.tgz",
+      "integrity": "sha512-rx+x8AMzKb5Q5lQ95Zoi6ZbJqwCLkqi3XuJXp5P3rT8OEc6sZCJG5AE5dU3lsgRr/F4Bs31jSlVN+j5KrsGu9A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "regexp-tree": "~0.1.1"
       }
     },
     "node_modules/safe-regex-test": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "eslint-plugin-import": "^2.32.0",
     "eslint-plugin-react": "^7.37.5",
     "eslint-plugin-react-hooks": "^5.2.0",
+    "eslint-plugin-security": "^3.0.1",
     "globals": "^16.3.0",
     "jsdom": "^26.1.0",
     "typescript": "^5.9.2",

--- a/src/services/cache/CacheStorage.ts
+++ b/src/services/cache/CacheStorage.ts
@@ -20,15 +20,22 @@ const TTL_MS = 24 * 60 * 60 * 1000;
 const L1_MAX = 200;
 const L2_MAX_ROWS = 1000;
 
-// Dynamic require helper
-const dynamicRequire: NodeRequire | null = (() => {
+// Dynamic require for optional dependencies - Node.js context only
+function getDynamicRequire(): NodeRequire | null {
+  // Process type guard for tree-shaking
+  if (typeof process === 'undefined' || process.type === 'renderer') {
+    return null; // Renderer context - no native modules
+  }
+
   try {
-     
-    return eval('require');
+    // Use createRequire in Node.js contexts (main process)
+    const { createRequire } = require('module');
+    return createRequire(import.meta.url);
   } catch {
     return null;
   }
-})();
+}
+const dynamicRequire = getDynamicRequire();
 
 type L1Value = CachedAnalysis;
 type L1Key = string;


### PR DESCRIPTION
- Replace eval('require') with process-type guarded createRequire() in cache services
- Add comprehensive process guards for Node.js vs renderer contexts
- Update ESLint security rules to be strict on eval but pragmatic on legitimate patterns
- Install and configure eslint-plugin-security for ongoing protection
- Verify zero unsafe patterns remain: no eval, new Function, or string-arg timers

🤖 Generated with [Claude Code](https://claude.ai/code)